### PR TITLE
Remove Comments & Compilation Step Only Feature

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,6 +7,10 @@ fi
 
 layout node
 
+if [ ! -f .git/hooks/pre-commit ]; then
+    pre-commit install
+fi
+
 # Export variables from .env
 watch_file .env
 set -a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests:
+  syntax-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,8 +16,7 @@ jobs:
         uses: cachix/install-nix-action@v30
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: workflow/nix-shell-action@v3
-        with:
-          flakes-from-devshell: true
-          custom-devshell: ciShell
-          script: make check
+      - name: Tests
+        run: |
+          nix develop
+          make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,4 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Tests
-        run: |
-          nix develop
-          make check
+        run: nix develop --impure --command make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,80 +8,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  fail_to_start:
+  tests:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      statuses: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - run: npm install
-      - uses: Certora/certora-run-action@main
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
         with:
-          use-beta: true
-          configurations: |-
-            tests/conf-start-error.conf
-            tests/conf-verified.conf --rule monotone --method "counter()"
-            tests/conf-violations.conf --method "counter()"
-            tests/conf-verified.conf
-            tests/conf-violations.conf --rule invertible
-            tests/conf-start-error.conf --method "counter()"
-          solc-versions: 0.7.6 0.8.1
-          job-name: "Fail to Start"
-          server: "vaas-dev"
-          certora-key: ${{ secrets.CERTORAKEY }}
-        env:
-          CERTORAKEY: ${{ secrets.CERTORAKEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  violated_rules:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      statuses: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - run: npm install
-      - uses: Certora/certora-run-action@main
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: workflow/nix-shell-action@v3
         with:
-          configurations: |-
-            tests/conf-verified.conf
-            tests/conf-violations.conf --rule invertible
-            tests/conf-verified.conf --method "counter()"
-            tests/conf-violations.conf
-          solc-versions: 0.7.6 0.8.1
-          job-name: "Violated Rules"
-          server: "vaas-dev"
-          certora-key: ${{ secrets.CERTORAKEY }}
-        env:
-          CERTORAKEY: ${{ secrets.CERTORAKEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  verified_rules:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      statuses: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - run: npm install
-      - uses: Certora/certora-run-action@main
-        with:
-          configurations: |-
-            tests/conf-verified.conf
-            tests/conf-verified.conf --rule monotone --method "counter()"
-            tests/conf-verified.conf --rule invertible
-            tests/conf-verified.conf --method "counter()"
-          solc-versions: 0.7.6 0.8.1
-          job-name: "Verified Rules"
-          server: "vaas-dev"
-          certora-key: ${{ secrets.CERTORAKEY }}
-        env:
-          CERTORAKEY: ${{ secrets.CERTORAKEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          flakes-from-devshell: true
+          custom-devshell: ciShell
+          script: make check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        entry: make
+        args: ["shellcheck"]
+        types: [bash]
+        language: system
+        pass_filenames: false
+      - id: github-action-syntax
+        name: github-action-syntax
+        entry: make
+        args: ["github-action-syntax"]
+        language: system
+        files: (^\.github\/.*\.yml$)|(^action\.yml$)
+        types: [yaml]
+        pass_filenames: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+BSD 4-Clause License
+
+Copyright (c) 2024, Certora Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. All advertising materials mentioning features or use of this software must
+   display the following acknowledgement:
+     This product includes software developed by Certora Ltd.
+
+4. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+.PHONY: default
+default: check
+
+.PHONY: check
+check: shellcheck github-action-syntax
+
+.PHONY: shellcheck
+shellcheck:
+	shellcheck scripts/*.sh
+
+.PHONY: github-action-syntax
+github-action-syntax:
+	action-validator action.yml .github/**/*.yml

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ jobs:
           job-name: "Verified Rules"
           certora-key: ${{ secrets.CERTORAKEY }}
         env:
-          CERTORAKEY: ${{ secrets.CERTORAKEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,14 @@ inputs:
     default: ${{ github.job }}
     description: |-
       The name of the job. Default is the name of the job that called this workflow.
+  install-java:
+    default: "true"
+    description: |-
+      Whether to install Java for type checking. Default is `true`.
+  compilation-steps-only:
+    default: "false"
+    description: |-
+      Whether to only run the compilation steps. Default is `false`.
 
 runs:
   using: "composite"
@@ -160,10 +168,30 @@ runs:
     - name: Download Solidity Binaries
       shell: bash
       run: |
-        find ${{ github.action_path }} -type f
         bash ${{ github.action_path }}/scripts/solc-download.sh \
           "${{ inputs.solc-remove-version-prefix }}" \
           "${{ inputs.solc-versions }}"
+
+    - name: Download Json Comment Remover
+      shell: bash
+      run: |
+        if [[ ! -f "/opt/solc-bin/json-strip-comments" ]]; then
+          curl -L \
+            -H "Accept: application/octet-stream" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -o "/opt/solc-bin/json-strip-comments" \
+            "https://api.github.com/repos/jc21/json-strip-comments/releases/assets/63648796"
+
+          chmod +x /opt/solc-bin/json-strip-comments
+        fi
+
+    - name: Install Java
+      if: ${{ inputs.install-java == "true" }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: "21"
+        java-package: jre
+        distribution: zulu
 
     - name: Certora Run
       id: certora-run
@@ -174,23 +202,26 @@ runs:
         CERTORA_SERVER: "${{ inputs.server }}"
         CERTORAKEY: "${{ inputs.certora-key }}"
         CERTORA_JOB_NAME: "${{ inputs.job-name }}"
+        CERTORA_COMPILATION_STEPS_ONLY: "${{ inputs.compilation-steps-only }}"
 
     - name: Add GH Status
       if: always()
       shell: bash
       run: |
-        curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
-          -d '{
-            "state":"pending",
-            "target_url":"https://${{ steps.setup-env.outputs.certora_subdomain }}.certora.com/?text=${{ steps.setup-env.outputs.short_sha }}&allUsers=true&groupIds=${{ steps.setup-env.outputs.group_id }}",
-            "description":"0/${{ steps.certora-run.outputs.total_jobs }} jobs finished.",
-            "context":"certora-run/${{ steps.setup-env.outputs.group_id }}"
-          }'
+        if [[ ${{ steps.certora-run.outputs.total_jobs }} -ne 0 ]]; then
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
+            -d '{
+              "state":"pending",
+              "target_url":"https://${{ steps.setup-env.outputs.certora_subdomain }}.certora.com/?text=${{ steps.setup-env.outputs.short_sha }}&allUsers=true&groupIds=${{ steps.setup-env.outputs.group_id }}",
+              "description":"0/${{ steps.certora-run.outputs.total_jobs }} jobs finished.",
+              "context":"certora-run/${{ steps.setup-env.outputs.group_id }}"
+            }'
+        fi
 
     - name: Upload Logs
       uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -186,7 +186,7 @@ runs:
         fi
 
     - name: Install Java
-      if: ${{ inputs.install-java == "true" }}
+      if: ${{ inputs.install-java == 'true' }}
       uses: actions/setup-java@v4
       with:
         java-version: "21"

--- a/flake.nix
+++ b/flake.nix
@@ -9,15 +9,21 @@
   outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
+        json-strip-comments-overlay = final: prev: {
+          json-strip-comments =
+            final.callPackage ./nix/json-strip-comments.nix { };
+        };
+
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ ];
+
+          overlays = [ json-strip-comments-overlay ];
         };
 
         devShell = with pkgs;
           mkShellNoCC {
             name = "cert-gh-run-action";
-            packages = [ act jq gh nodejs ];
+            packages = [ act jq gh nodejs json-strip-comments ];
 
             nativeBuildInputs = [
               # set SOURCE_DATE_EPOCH so that we can use python wheels

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
         ciShell = with pkgs;
           mkShellNoCC {
             name = "cert-gh-run-action-ci";
-            packages = test_packages;
+            buildInputs = test_packages;
           };
       in {
         devShell = devShell;

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,16 @@
         devShell = with pkgs;
           mkShellNoCC {
             name = "cert-gh-run-action";
-            packages = [ act jq gh nodejs json-strip-comments ];
+            packages = [
+              act
+              jq
+              gh
+              nodejs
+              action-validator
+              shellcheck
+              pre-commit
+              json-strip-comments
+            ];
 
             nativeBuildInputs = [
               # set SOURCE_DATE_EPOCH so that we can use python wheels

--- a/flake.nix
+++ b/flake.nix
@@ -20,19 +20,13 @@
           overlays = [ json-strip-comments-overlay ];
         };
 
+        test_packages = with pkgs; [ action-validator shellcheck ];
+
         devShell = with pkgs;
           mkShellNoCC {
             name = "cert-gh-run-action";
-            packages = [
-              act
-              jq
-              gh
-              nodejs
-              action-validator
-              shellcheck
-              pre-commit
-              json-strip-comments
-            ];
+            packages = [ act jq gh nodejs pre-commit json-strip-comments ]
+              ++ test_packages;
 
             nativeBuildInputs = [
               # set SOURCE_DATE_EPOCH so that we can use python wheels
@@ -40,8 +34,14 @@
             ];
 
           };
+        ciShell = with pkgs;
+          mkShellNoCC {
+            name = "cert-gh-run-action-ci";
+            packages = test_packages;
+          };
       in {
         devShell = devShell;
+        ciShell = ciShell;
         packages = { dev-shell = devShell.inputDerivation; };
       });
 }

--- a/nix/json-strip-comments.nix
+++ b/nix/json-strip-comments.nix
@@ -1,0 +1,24 @@
+{ buildGoModule, fetchFromGitHub, }:
+
+buildGoModule rec {
+  pname = "jc21";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jc21";
+    repo = "json-strip-comments";
+    rev = "v${version}";
+    hash = "sha256-ueqjX6Elqs9Kwj2BICy1isTN644JR4w22NtPRI+qXhY=";
+  };
+
+  vendorHash = "sha256-WcWuald1sZKFcPbG1PP7BZN5AaTk3UzkhIIGHnNQTzU=";
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = {
+    homepage = "https://github.com/jc21/json-strip-comments";
+    description =
+      "This is a very simple command that will remove comments from JSON files.";
+    mainProgram = "json-strip-comments";
+  };
+}

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -79,11 +79,22 @@ for i in "${!pids[@]}"; do
     ((failed_jobs++)) || true
     echo "| ${configs[i]} | Failed ($ret) | - | ${logs[i]#$CERTORA_LOG_DIR} |" >> "$CERTORA_REPORT_FILE"
   else
-    LINK=$(grep -oE "https://(vaas-dev|vaas-stg|prover)\.certora\.com/[^/]+/[0-9]+/[a-zA-Z0-9-]+/?.*\?.*anonymousKey=[a-zA-Z0-9-]+" "${logs[i]}" || true)
-    echo "| ${configs[i]} | Submited | [link]($LINK) | ${logs[i]#$CERTORA_LOG_DIR} |" >> "$CERTORA_REPORT_FILE"
-    if [[ -z "$LINK" ]]; then
-      ((jobs--)) || true
+    if [[ "$CERTORA_COMPILATION_STEPS_ONLY" == 'true' ]]; then
+        STATUS="Compiled"
+    else
+        STATUS="Submited"
     fi
+
+    LINK=$(grep -oE "https://(vaas-dev|vaas-stg|prover)\.certora\.com/[^/]+/[0-9]+/[a-zA-Z0-9-]+/?.*\?.*anonymousKey=[a-zA-Z0-9-]+" "${logs[i]}" || true)
+    if [[ -z "$LINK" ]]; then
+        ((jobs--)) || true
+        MD_LINK="-"
+    else
+        MD_LINK="[link]($LINK)"
+    fi
+
+    echo "| ${configs[i]} | $STATUS | $MD_LINK | ${logs[i]#$CERTORA_LOG_DIR} |" >> "$CERTORA_REPORT_FILE"
+
   fi
 done
 

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 
 MAX_MSG_LEN=254
 SUFFIX_LEN=${#MESSAGE_SUFFIX}
@@ -29,7 +28,6 @@ for conf_line in "${confs[@]}"; do
   echo "Sanitizing $conf_file"
   cat "$conf_file"
   tmp_conf=$(mktemp)
-  json-strip-comments --help
   json-strip-comments -e -o "$tmp_conf" < "$conf_file"
   if [[ "$(jq 'has("wait_for_results")' "$tmp_conf")" == 'true' ]]; then
     jq 'del(.wait_for_results)' "$tmp_conf" > "$conf_file"

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -26,7 +26,6 @@ for conf_line in "${confs[@]}"; do
   conf_file="${conf_parts[0]}"
 
   echo "Sanitizing $conf_file"
-  cat "$conf_file"
   tmp_conf=$(mktemp)
   json-strip-comments -e -o "$tmp_conf" < "$conf_file"
   if [[ "$(jq 'has("wait_for_results")' "$tmp_conf")" == 'true' ]]; then
@@ -34,7 +33,6 @@ for conf_line in "${confs[@]}"; do
   else
     mv "$tmp_conf" "$conf_file"
   fi
-  cat "$conf_file"
 
   echo "Starting '$conf_line' with message: $MSG_CONF"
 

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -29,7 +29,8 @@ for conf_line in "${confs[@]}"; do
   echo "Sanitizing $conf_file"
   cat "$conf_file"
   tmp_conf=$(mktemp)
-  json-strip-comments -e "$conf_file" > "$tmp_conf"
+  json-strip-comments --help
+  json-strip-comments -e "$conf_file" -o "$tmp_conf"
   if [[ "$(jq 'has("wait_for_results")' "$tmp_conf")" == 'true' ]]; then
     jq 'del(.wait_for_results)' "$tmp_conf" > "$conf_file"
   else

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -27,13 +27,15 @@ for conf_line in "${confs[@]}"; do
   conf_file="${conf_parts[0]}"
 
   echo "Sanitizing $conf_file"
+  cat "$conf_file"
   tmp_conf=$(mktemp)
-  json-strip-comments -e -o "$tmp_conf" "$conf_file"
+  json-strip-comments -e "$conf_file" > "$tmp_conf"
   if [[ "$(jq 'has("wait_for_results")' "$tmp_conf")" == 'true' ]]; then
     jq 'del(.wait_for_results)' "$tmp_conf" > "$conf_file"
   else
     mv "$tmp_conf" "$conf_file"
   fi
+  cat "$conf_file"
 
   echo "Starting '$conf_line' with message: $MSG_CONF"
 

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -30,7 +30,7 @@ for conf_line in "${confs[@]}"; do
   cat "$conf_file"
   tmp_conf=$(mktemp)
   json-strip-comments --help
-  json-strip-comments -e "$conf_file" -o "$tmp_conf"
+  json-strip-comments -e -o "$tmp_conf" < "$conf_file"
   if [[ "$(jq 'has("wait_for_results")' "$tmp_conf")" == 'true' ]]; then
     jq 'del(.wait_for_results)' "$tmp_conf" > "$conf_file"
   else

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -29,7 +29,7 @@ for conf_line in "${confs[@]}"; do
   echo "Sanitizing $conf_file"
   tmp_conf=$(mktemp)
   json-strip-comments -e -o "$tmp_conf" "$conf_file"
-  if [[ $(jq 'has("wait_for_results")' "$tmp_conf") == "true" ]]; then
+  if [[ "$(jq 'has("wait_for_results")' "$tmp_conf")" == 'true' ]]; then
     jq 'del(.wait_for_results)' "$tmp_conf" > "$conf_file"
   else
     mv "$tmp_conf" "$conf_file"
@@ -43,7 +43,7 @@ for conf_line in "${confs[@]}"; do
   mkdir -p "$(dirname "$LOG_FILE")"
   logs+=("$LOG_FILE")
 
-  if [[ "$CERTORA_COMPILATION_STEPS_ONLY" == "true" ]]; then
+  if [[ "$CERTORA_COMPILATION_STEPS_ONLY" == 'true' ]]; then
     conf_parts+=("--compilation_steps_only")
   fi
 

--- a/tests/conf-violations.conf
+++ b/tests/conf-violations.conf
@@ -2,7 +2,11 @@
   "files": ["tests/Invertible.sol:InvertibleBroken"],
   "packages": ["base64-sol=node_modules/base64-sol"],
   "process": "emv",
+  /*
+  Multi line comments are removed as well \o/
+  */
   "solc": "solc0.7.6",
+  // This is a comment
   "verify": "InvertibleBroken:tests/TestSpec.spec",
   "wait_for_results": "all"
 }


### PR DESCRIPTION
This PR adds:
- java installation for type-checking support
- remove comments from conf files so we can use `jq`
- add an option for `--compilation_steps_only`
- adding license

Successful execution: https://github.com/Certora/certora-run-action-test/pull/5