### PR TITLE
Isolated Environments and Remove the Longest Common Prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,19 +177,6 @@ runs:
           "${{ inputs.solc-remove-version-prefix }}" \
           "${{ inputs.solc-versions }}"
 
-    - name: Download Json Comment Remover
-      shell: bash
-      run: |
-        if [[ ! -f "/opt/solc-bin/json-strip-comments" ]]; then
-          curl -L \
-            -H "Accept: application/octet-stream" \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -o "/opt/solc-bin/json-strip-comments" \
-            "https://api.github.com/repos/jc21/json-strip-comments/releases/assets/63648796"
-
-          chmod +x /opt/solc-bin/json-strip-comments
-        fi
-
     - name: Install Java
       if: ${{ inputs.install-java == 'true' }}
       uses: actions/setup-java@v4

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -19,10 +19,11 @@ current_dir="$(pwd)"
 
 for conf_line in "${confs[@]}"; do
 
-  if [[ ${#conf_line} -gt $MAX_MSG_LEN ]]; then
-    MSG_CONF="${conf_line: -$REMAINING_LEN}"
+  short_conf_line="${conf_line#"$common_prefix"}"
+  if [[ ${#short_conf_line} -gt $MAX_MSG_LEN ]]; then
+    MSG_CONF="${short_conf_line: -$REMAINING_LEN}"
   else
-    MSG_CONF="$conf_line"
+    MSG_CONF="$short_conf_line"
   fi
 
   conf_parts=()

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -42,7 +42,7 @@ for conf_line in "${confs[@]}"; do
 
   # Create log files
   RAND_SUFF=$(openssl rand -hex 6)
-  LOG_FILE="$(printf "%s" "${CERTORA_LOG_DIR}${conf_file#"$common_prefix"}-${RAND_SUFF}.log" | tr -s '/')"
+  LOG_FILE="$(printf "%s" "${CERTORA_LOG_DIR}${conf_file}-${RAND_SUFF}.log" | tr -s '/')"
   mkdir -p "$(dirname "$LOG_FILE")"
   logs+=("$LOG_FILE")
 

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -13,6 +13,10 @@ IFS=$'\n' read -rd '' -a confs <<< "$(echo "$CERTORA_CONFIGURATIONS" | sort -u)"
 
 echo "Configurations: ${confs[*]}"
 
+# Sed script to extract the common prefix
+# For the first line, copy pattern space to hold space and delete the pattern space
+# Append a newline and the hold space to the pattern space, capture the common prefix
+# Copy the pattern space to the hold space and delete the pattern space until the last line
 common_prefix="$(echo "$CERTORA_CONFIGURATIONS" | sed -e '1{h;d;}' -e 'G;s,\(.*\).*\n\1.*,\1,;h;$!d' | tr -d '\n')"
 
 current_dir="$(pwd)"

--- a/tests/conf-violations.conf
+++ b/tests/conf-violations.conf
@@ -7,6 +7,5 @@
   */
   "solc": "solc0.7.6",
   // This is a comment
-  "verify": "InvertibleBroken:tests/TestSpec.spec",
-  "wait_for_results": "all"
+  "verify": "InvertibleBroken:tests/TestSpec.spec"
 }


### PR DESCRIPTION
In this PR we're:
1. Adding `cp -lRP` to create an isolated env for each run.
2. Removing comment striping.
3. Removing the longest common prefix from all tables.

Successful executions:
- https://github.com/Certora/certora-run-action-test/pull/7
- https://github.com/Certora/aave-governance-v3/pull/31 (last one)