### PR TITLE
Fix cli version inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,17 +152,17 @@ runs:
       shell: bash
       run: |
         CERT_CLI_PACKAGE="certora-cli"
-          if [ '${{ inputs.use_alpha }}' == 'true' ]; then
+          if [ '${{ inputs.use-alpha }}' == 'true' ]; then
             CERT_CLI_PACKAGE="certora-cli-alpha"
-          elif [ '${{ inputs.use_beta }}' == 'true' ]; then
+          elif [ '${{ inputs.use-beta }}' == 'true' ]; then
             CERT_CLI_PACKAGE="certora-cli-beta"
           fi
         CERT_CLI_PACKAGE="${CERT_CLI_PACKAGE}${CERT_CLI_VERSION:+==$CERT_CLI_VERSION}"
         echo "CERT_CLI_PACKAGE=$CERT_CLI_PACKAGE" >> $GITHUB_ENV
-        echo "Running with version $CERT_CLI_PACKAGE"
+        echo "Running with version "
         uv tool install "$CERT_CLI_PACKAGE"
       env:
-        CERT_CLI_VERSION: ${{ inputs.cli_version }}
+        CERT_CLI_VERSION: ${{ inputs.cli-version }}
 
     - name: Cache Solidity Binaries
       id: solc-cache

--- a/action.yml
+++ b/action.yml
@@ -159,7 +159,7 @@ runs:
           fi
         CERT_CLI_PACKAGE="${CERT_CLI_PACKAGE}${CERT_CLI_VERSION:+==$CERT_CLI_VERSION}"
         echo "CERT_CLI_PACKAGE=$CERT_CLI_PACKAGE" >> $GITHUB_ENV
-        echo "Running with version "
+        echo "Using version $CERT_CLI_PACKAGE"
         uv tool install "$CERT_CLI_PACKAGE"
       env:
         CERT_CLI_VERSION: ${{ inputs.cli-version }}

--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,7 @@ runs:
           fi
         CERT_CLI_PACKAGE="${CERT_CLI_PACKAGE}${CERT_CLI_VERSION:+==$CERT_CLI_VERSION}"
         echo "CERT_CLI_PACKAGE=$CERT_CLI_PACKAGE" >> $GITHUB_ENV
+        echo "Running with version $CERT_CLI_PACKAGE"
         uv tool install "$CERT_CLI_PACKAGE"
       env:
         CERT_CLI_VERSION: ${{ inputs.cli_version }}


### PR DESCRIPTION
Choosing a specific version of certora-cli didn't work because of wrong inputs name.