### PR TITLE
Using first solidity version as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ besides the permissions, the action requires the following secrets:
 ### Inputs
 
 - `configurations` - List of configuration files to run.
-- `solc-versions` - List of Solidity versions to download. The first version in the list will be used as the default version (solc binary).
+- `solc-versions` - List of Solidity versions to download. The first version in the list will also be available as `solc` in the environment.
 - `cli-version` - Version of the `certora-cli` to use (optional). By default, the latest version is used. This action is compatible with versions `7.9.0` and above.
 - `use-alpha` - Use the alpha version of the `certora-cli` (optional).
 - `use-beta` - Use the beta version of the `certora-cli` (optional).

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ besides the permissions, the action requires the following secrets:
 ### Inputs
 
 - `configurations` - List of configuration files to run.
-- `solc-versions` - List of Solidity versions to download.
+- `solc-versions` - List of Solidity versions to download. The first version in the list will be used as the default version (solc binary).
 - `cli-version` - Version of the `certora-cli` to use (optional). By default, the latest version is used. This action is compatible with versions `7.9.0` and above.
 - `use-alpha` - Use the alpha version of the `certora-cli` (optional).
 - `use-beta` - Use the beta version of the `certora-cli` (optional).

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,8 @@ inputs:
   solc-versions:
     required: true
     description: |-
-      List of Solidity versions to use for the `certoraRun` command.
+      List of Solidity versions to use for the `certoraRun` command. The first version
+      in the list will be used as the default version (solc binary).
 
       Example:
 

--- a/scripts/solc-download.sh
+++ b/scripts/solc-download.sh
@@ -40,15 +40,15 @@ for version in $VERSIONS; do
     # Verify the binary
     chmod +x "$BIN_PATH"
     "solc$use_version" --version
+  fi
 
-    # Create a symlink for the first version if the binary name isn't already 'solc'
-    if [ "$FIRST_VERSION" = true ] && [ "$BIN_PATH" != "/opt/solc-bin/solc" ]; then
-      rm -f /opt/solc-bin/solc # Remove existing symlink if it exists
-      ln -s "$BIN_PATH" /opt/solc-bin/solc
-      echo "Created symlink: solc -> solc$use_version"
-      solc --version
-      FIRST_VERSION=false
-    fi
+  # Create a symlink for the first version if the binary name isn't already 'solc'
+  if [ "$FIRST_VERSION" = true ] && [ "$BIN_PATH" != "/opt/solc-bin/solc" ]; then
+    rm -f /opt/solc-bin/solc # Remove existing symlink if it exists
+    ln -s "$BIN_PATH" /opt/solc-bin/solc
+    echo "Created symlink: solc -> solc$use_version"
+    solc --version
+    FIRST_VERSION=false
   fi
 done
 


### PR DESCRIPTION
This PR adds a `solc` symlink to the first Solidity version in the list. Thus, we can specify `solc` in the config files.

PR was tested using multiple configurations in this PR: https://github.com/Certora/certora-run-action-test/pull/10