### PR TITLE
CERT-8473 | Add a flag for adding a pr comment only when failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ besides the permissions, the action requires the following secrets:
 - `install-java` - Install Java for type checking (optional). Default is `true`.
 - `compilation-steps-only` - Compile the spec and the code without sending a
   verification request to the cloud (optional). Default is `false`.
+- `comment-fail-only` - Add a report comment to the pr only when the job fail (optional). Default it `true`.
 - `certora-key` - API key for Certora Prover.
 
 ### Comments on the Pull Request

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ inputs:
     description: |-
       Whether to only run the compilation steps. Default is `false`.
   comment-fail-only:
-    default: "false"
+    default: "true"
     description: |-
       Add a comment to the PR only if the run fail.
 

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,10 @@ inputs:
     default: "false"
     description: |-
       Whether to only run the compilation steps. Default is `false`.
+  comment-fail-only:
+    default: "false"
+    description: |-
+      Add a comment to the PR only if the run fail.
 
 runs:
   using: "composite"
@@ -232,7 +236,7 @@ runs:
         echo "[Download Logs](${{ steps.upload-logs.outputs.artifact-url }})" >> "${{ steps.setup-env.outputs.report_file }}"
 
     - name: Add report comment
-      if: always()
+      if: ${{ failure() || inputs.comment-fail-only == 'false' }}
       uses: mshick/add-pr-comment@v2
       with:
         message-id: ${{ steps.setup-env.outputs.group_id }}


### PR DESCRIPTION
Add support for choosing whether to add a comment to the pr always or only when the run fail.