### PR TITLE
[CERT-8644] Create solc-<version> and solc<version> aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ besides the permissions, the action requires the following secrets:
 ### Inputs
 
 - `configurations` - List of configuration files to run.
-- `solc-versions` - List of Solidity versions to download. The first version in the list will also be available as `solc` in the environment.
+- `solc-versions` - List of Solidity versions to download. The first version in the list
+  will also be available as `solc` in the environment. Each version will be available as
+  as both `solc<version>` and `solc-<version>` in the environment.
 - `cli-version` - Version of the `certora-cli` to use (optional). By default, the latest version is used. This action is compatible with versions `7.9.0` and above.
 - `use-alpha` - Use the alpha version of the `certora-cli` (optional).
 - `use-beta` - Use the beta version of the `certora-cli` (optional).

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     description: |-
       List of Solidity versions to use for the `certoraRun` command. The first version
       in the list will be used as the default version (solc binary). Each version will
-      be available as as both `solc<version>` and `solc-<version>` in the environment.
+      be available as both `solc<version>` and `solc-<version>` in the environment.
 
       Example:
 

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,8 @@ inputs:
     required: true
     description: |-
       List of Solidity versions to use for the `certoraRun` command. The first version
-      in the list will be used as the default version (solc binary).
+      in the list will be used as the default version (solc binary). Each version will
+      be available as as both `solc<version>` and `solc-<version>` in the environment.
 
       Example:
 

--- a/scripts/solc-download.sh
+++ b/scripts/solc-download.sh
@@ -42,6 +42,16 @@ for version in $VERSIONS; do
     "solc$use_version" --version
   fi
 
+  # create two symlinks for the binary, solc$version and solc-$version if they don't exist
+  if [ ! -e "/opt/solc-bin/solc$version" ]; then
+    ln -s "$BIN_PATH" "/opt/solc-bin/solc$version"
+    echo "Created symlink: solc$version -> $BIN_PATH"
+  fi
+  if [ ! -e "/opt/solc-bin/solc-$version" ]; then
+    ln -s "$BIN_PATH" "/opt/solc-bin/solc-$version"
+    echo "Created symlink: solc-$version -> $BIN_PATH"
+  fi
+
   # Create a symlink for the first version if the binary name isn't already 'solc'
   if [ "$FIRST_VERSION" = true ] && [ "$BIN_PATH" != "/opt/solc-bin/solc" ]; then
     rm -f /opt/solc-bin/solc # Remove existing symlink if it exists


### PR DESCRIPTION
As some of our customers are using `solc-<version>` and `solc<version>` binaries (or combinations), we want to make sure that both are available.