### PR TITLE
Add Certora key and GH Token input validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
           exit 1
         fi
 
-        if [[ -z "$GITHUB_TOKEN" }}" ]]; then
+        if [[ -z "$GITHUB_TOKEN" ]]; then
           echo "::error title=GitHub Token is missing::GitHub token is required for this action. Please provide a valid token as an environment variable."
           exit 1
         fi

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ inputs:
   comment-fail-only:
     default: "true"
     description: |-
-      Add a comment to the PR only if the run fail.
+      Add a comment to the PR only if the run fails.
 
 runs:
   using: "composite"
@@ -94,7 +94,7 @@ runs:
       shell: bash
       run: |
         if [[ -z "${{ inputs.certora-key }}" ]]; then
-          echo "::error title=Certora Key is missing::Certora key is required to run the prover jobs. Please provide a valid key as an secret input."
+          echo "::error title=Certora Key is missing::Certora key is required to run the prover jobs. Please provide a valid key as a secret input."
           exit 1
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Verify Certora key and GitHub Token
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.certora-key }}" ]]; then
+          echo "::error title=Certora Key is missing::Certora key is required to run the prover jobs. Please provide a valid key as an secret input."
+          exit 1
+        fi
+
+        if [[ -z "$GITHUB_TOKEN" }}" ]]; then
+          echo "::error title=GitHub Token is missing::GitHub token is required for this action. Please provide a valid token as an environment variable."
+          exit 1
+        fi
     - name: Fetch Relevant Commit SHA for the Event
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -94,22 +94,15 @@ runs:
       shell: bash
       run: |
         FAILED=false
-
+        DOC_LINK="For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
         if [[ -z "${{ inputs.certora-key }}" ]]; then
-          MESSAGE="Certora key is missing. Please provide a valid key as a secret input.
-
-          For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
-
+          MESSAGE="Certora key is missing. Please provide a valid key as a secret input. $DOC_LINK"
           echo "::error title=Certora Key is missing::$MESSAGE"
           FAILED=true
         fi
 
         if [[ -z "$GITHUB_TOKEN" ]]; then
-
-          MESSAGE="GitHub token is missing. Please provide a valid token as an environment variable.
-
-          For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
-
+          MESSAGE="GitHub token is missing. Please provide a valid token as an environment variable. $DOC_LINK"
           echo "::error title=GitHub Token is missing::$MESSAGE"
           FAILED=true
         fi

--- a/action.yml
+++ b/action.yml
@@ -93,13 +93,42 @@ runs:
     - name: Verify Certora key and GitHub Token
       shell: bash
       run: |
+        FAILED=false
+
         if [[ -z "${{ inputs.certora-key }}" ]]; then
-          echo "::error title=Certora Key is missing::Certora key is required to run the prover jobs. Please provide a valid key as a secret input."
-          exit 1
+          MESSAGE="Certora key is missing. Please provide a valid key as a secret input.
+
+          Example:
+
+          ```yaml
+          with:
+            certora-key: \${{ secrets.CERTORA_KEY }}
+          ```
+
+          For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
+
+          echo "::error title=Certora Key is missing::$MESSAGE"
+          FAILED=true
         fi
 
         if [[ -z "$GITHUB_TOKEN" ]]; then
-          echo "::error title=GitHub Token is missing::GitHub token is required for this action. Please provide a valid token as an environment variable."
+
+          MESSAGE="GitHub token is missing. Please provide a valid token as an environment variable.
+
+          Example:
+
+          ```yaml
+          env:
+            GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          ```
+
+          For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
+
+          echo "::error title=GitHub Token is missing::$MESSAGE"
+          FAILED=true
+        fi
+
+        if [[ "$FAILED" == "true" ]]; then
           exit 1
         fi
     - name: Fetch Relevant Commit SHA for the Event

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
 
           ```yaml
           with:
-            certora-key: \${{ secrets.CERTORA_KEY }}
+            certora-key: ${{ '$' }}{{ secrets.CERTORAKEY }}
           ```
 
           For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
@@ -119,7 +119,7 @@ runs:
 
           ```yaml
           env:
-            GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ '$' }}{{ secrets.GITHUB_TOKEN }}
           ```
 
           For more details please refer to the documentation at https://github.com/Certora/certora-run-action"

--- a/action.yml
+++ b/action.yml
@@ -98,13 +98,6 @@ runs:
         if [[ -z "${{ inputs.certora-key }}" ]]; then
           MESSAGE="Certora key is missing. Please provide a valid key as a secret input.
 
-          Example:
-
-          ```yaml
-          with:
-            certora-key: ${{ '$' }}{{ secrets.CERTORAKEY }}
-          ```
-
           For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
 
           echo "::error title=Certora Key is missing::$MESSAGE"
@@ -114,13 +107,6 @@ runs:
         if [[ -z "$GITHUB_TOKEN" ]]; then
 
           MESSAGE="GitHub token is missing. Please provide a valid token as an environment variable.
-
-          Example:
-
-          ```yaml
-          env:
-            GITHUB_TOKEN: ${{ '$' }}{{ secrets.GITHUB_TOKEN }}
-          ```
 
           For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
 

--- a/action.yml
+++ b/action.yml
@@ -94,15 +94,15 @@ runs:
       shell: bash
       run: |
         FAILED=false
-        DOC_LINK="For more details please refer to the documentation at https://github.com/Certora/certora-run-action"
+        DOC_LINK="For more details please refer to the documentation at https://github.com/Certora/certora-run-action."
         if [[ -z "${{ inputs.certora-key }}" ]]; then
-          MESSAGE="Certora key is missing. Please provide a valid key as a secret input. $DOC_LINK"
+          MESSAGE="Please provide a valid Certora key as a secret input. $DOC_LINK"
           echo "::error title=Certora Key is missing::$MESSAGE"
           FAILED=true
         fi
 
         if [[ -z "$GITHUB_TOKEN" ]]; then
-          MESSAGE="GitHub token is missing. Please provide a valid token as an environment variable. $DOC_LINK"
+          MESSAGE="Please provide a valid GitHub token as an environment variable. $DOC_LINK"
           echo "::error title=GitHub Token is missing::$MESSAGE"
           FAILED=true
         fi


### PR DESCRIPTION
This PR adds input validation and a simple fail message for both GitHub token and Certora key inputs.

Example:
![image](https://github.com/user-attachments/assets/a7de8fac-3077-4427-a3f4-356fd9ac620e)

