### PR TITLE
[CERT-8712] Fix prefix remover

### DIFF
--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -25,7 +25,7 @@ if [[ ${#confs[@]} -gt 1 ]]; then
   common_prefix="$(echo "$CERTORA_CONFIGURATIONS" | sed -e '1{h;d;}' -e 'G;s,\(.*\).*\n\1.*,\1,;s,\(.*[/ ]\).*$,\1,;h;$!d' | tr -d '\n')"
 else
   # Keep the file name only
-  common_prefix="$(echo "${confs[0]}" | sed -r 's/^[^ ]*\///g')"
+  common_prefix="$(echo "${confs[0]}" | sed 's/\(.*\/\)[^\/]*$/\1/')"
 fi
 
 current_dir="$(pwd)"

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -9,8 +9,8 @@ pids=()
 configs=()
 logs=()
 
-# Remove leading spaces, comments, and empty lines
-CERTORA_CONFIGURATIONS="$(sed -r 's/^\s+//; /^[[:blank:]]*#/d; s/^#.*//; /^\s*$/d' <<<"$CERTORA_CONFIGURATIONS")"
+# Remove leading spaces, trailing spaces, comments, and empty lines
+CERTORA_CONFIGURATIONS="$(sed -r 's/^\s+//; s/\s+$//; /^[[:blank:]]*#/d; s/^#.*//; /^\s*$/d' <<<"$CERTORA_CONFIGURATIONS")"
 
 IFS=$'\n' read -rd '' -a confs <<<"$(echo "$CERTORA_CONFIGURATIONS" | sort -u)"
 


### PR DESCRIPTION
This PR fixes several issues with the prefix remover:

1. For a single configuration, it keeps only the file name.
2. For multiple configurations, it will only remove full path parts.
3. It will handle comments, leading spaces, trailing spaces, and empty lines.