### PR TITLE
Add debug options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,11 @@ inputs:
     default: "true"
     description: |-
       Add a comment to the PR only if the run fails.
+  debug-level:
+    default: "0"
+    description: |-
+      The debug level to use for the action command. Default is `0`.
+      Options: `0`, `1`, `2`, or `3`.
 
 runs:
   using: "composite"
@@ -203,6 +208,8 @@ runs:
         bash ${{ github.action_path }}/scripts/solc-download.sh \
           "${{ inputs.solc-remove-version-prefix }}" \
           "${{ inputs.solc-versions }}"
+      env:
+        DEBUG_LEVEL: "${{ inputs.debug-level }}"
 
     - name: Install Java
       if: ${{ inputs.install-java == 'true' }}
@@ -229,6 +236,7 @@ runs:
         CERTORAKEY: "${{ inputs.certora-key }}"
         CERTORA_JOB_NAME: "${{ inputs.job-name }}"
         CERTORA_COMPILATION_STEPS_ONLY: "${{ inputs.compilation-steps-only }}"
+        DEBUG_LEVEL: "${{ inputs.debug-level }}"
 
     - name: Add GH Status
       if: always()

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ "$DEBUG_LEVEL" -gt 0 ]; then
+  set -x
+fi
+
 MAX_MSG_LEN=254
 SUFFIX_LEN=${#MESSAGE_SUFFIX}
 REMAINING_LEN=$((MAX_MSG_LEN - SUFFIX_LEN))
@@ -62,7 +66,15 @@ for conf_line in "${confs[@]}"; do
     conf_parts+=("--compilation_steps_only")
   fi
 
+  if [ "$DEBUG_LEVEL" -gt 1 ]; then
+    conf_parts+=("--debug")
+  fi
+
   cd "$run_dir" || continue
+
+  if [ "$DEBUG_LEVEL" -gt 2 ]; then
+    find . -exec stat -c'%U %G %a %n' {} \;
+  fi
 
   uvx --from "$CERT_CLI_PACKAGE" certoraRun "${conf_parts[@]}" \
     --msg "${MSG_CONF} ${MESSAGE_SUFFIX}" \

--- a/scripts/solc-download.sh
+++ b/scripts/solc-download.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ "$DEBUG_LEVEL" -gt 0 ]; then
+  set -x
+fi
+
 REMOVE_PREFIX="$1"
 
 mkdir -p /opt/solc-bin


### PR DESCRIPTION
This PR adds some basic debugging options like `set -x`, listing all available files, and adding `--debug` flag to certora run. @Certora/cloud-team, do you know any other debug options we would like to add?

### ✅ Tests Checklist

- [X] **`fail_to_start`**
  - Status: ❌ Failed with compilation error  
  - Compilation Comment: 🟢 Yes
  - Results Review: 🔴 No  
  

- [X] **`violated_rules`**
  - Status: ✅ Passed, with violations found  
  - Compilation Comment: 🔴 No
  - Results Review: 🟢 Yes  

- [X] **`verified_rules`**
  - Status: ✅ Passed without violations  
  - Compilation Comment: 🔴 No
  - Results Review: 🟢 Yes  
  