### PR TITLE
Add support for working-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ besides the permissions, the action requires the following secrets:
   verification request to the cloud (optional). Default is `false`.
 - `comment-fail-only` - Add a report comment to the pr only when the job fail (optional). Default it `true`.
 - `certora-key` - API key for Certora Prover.
+- `working-directory` - Working directory to run the action in (optional). Default is the root of the repository.
 
 ### Comments on the Pull Request
 

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,10 @@ inputs:
     description: |-
       The debug level to use for the action command. Default is `0`.
       Options: `0`, `1`, `2`, or `3`.
+  working-directory:
+    default: ${{ github.workspace }}
+    description: |-
+      The working directory to run the action in. Default is the current working directory.
 
 runs:
   using: "composite"
@@ -221,6 +225,7 @@ runs:
 
     - name: Certora Run
       id: certora-run
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         RUN_CERTORA="${{ github.action_path }}/scripts/run-certora.sh"


### PR DESCRIPTION
This PR adds support for `working-directory` in order to call `certoraRun` outside of the default GH workdir.

### ✅ Tests Checklist

- [ ] **`fail_to_start`**
  - Status: ❌ Failed with compilation error  
  - Compilation Comment: 🟢 Yes
  - Results Review: 🔴 No  
  

- [ ] **`violated_rules`**
  - Status: ✅ Passed, with violations found  
  - Compilation Comment: 🔴 No
  - Results Review: 🟢 Yes  

- [ ] **`verified_rules`**
  - Status: ✅ Passed without violations  
  - Compilation Comment: 🔴 No
  - Results Review: 🟢 Yes  
  