### PR TITLE
Generate solc cache key from versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -227,6 +227,8 @@ runs:
           CERTORA_API_SUBDOMAIN="data-api-stg"
         fi
 
+        echo "solc_cache_key=$(md5sum <<< '${{ inputs.solc-versions }}' | awk '{ print $1 }')" >> "$GITHUB_OUTPUT"
+
         echo "CERTORA_ACTION_REF=$CERTORA_ACTION_REF" >> "$GITHUB_ENV"
         echo "CERTORA_SUBDOMAIN=$CERTORA_SUBDOMAIN" >> "$GITHUB_ENV"
         echo "certora_subdomain=$CERTORA_SUBDOMAIN" >> "$GITHUB_OUTPUT"
@@ -264,11 +266,14 @@ runs:
         CERT_CLI_VERSION: ${{ inputs.cli-version }}
 
     - name: Cache Solidity Binaries
+      if: ${{ inputs.solc-versions }}
       id: solc-cache
       uses: actions/cache@v4
       with:
         path: /opt/solc-bin
-        key: solc-bin
+        key: solc-bin-${{ steps.setup-env.outputs.solc_cache_key }}
+        restore-keys: |
+          solc-bin
 
     - name: Download Solidity Binaries
       if: ${{ inputs.solc-versions }}


### PR DESCRIPTION
## 🚀 Pull Request Overview

This PR adds a hash of Solc versions for the cache key generation and adds restore keys for backward compatibility. This change helps with refreshing the cache on Solc version changes.

---

### 📜 Tests Checklist

Before submitting this PR, ensure that all tests pass **and** meet the following conditions:

| Category                  | Status                          | Compilation Comment | Results Review |
|---------------------------|----------------------------------|----------------------|----------------|
| **fail_to_start**         | ❌ Failed with compilation error | 🟢 Yes               | 🔴 No          |
| **violated_rules**        | ✅ Passed, with violations found | 🔴 No                | 🟢 Yes         |
| **verified_rules**        | ✅ Passed without violations     | 🔴 No                | 🟢 Yes         |
| **solana_violated_rules** | ✅ Passed, with violations found | 🔴 No                | 🟢 Yes         |

> Please verify that your changes meet the above conditions for each category of tests.  
> If something doesn't match, investigate before submitting the PR.

---
