### PR TITLE
Verify SHA-256 of downloaded solc binaries

### DIFF
--- a/scripts/solc-download.sh
+++ b/scripts/solc-download.sh
@@ -81,22 +81,23 @@ for version in $VERSIONS; do
     verify_sha256 "$version" "$BIN_PATH"
   fi
 
-  # create two symlinks for the binary, solc$version and solc-$version if they don't exist
-  if [ ! -e "/opt/solc-bin/solc$version" ]; then
-    ln -s "$BIN_PATH" "/opt/solc-bin/solc$version"
-    echo "Created symlink: solc$version -> $BIN_PATH"
+  # Recreate aliases so they always point at the just-verified $BIN_PATH.
+  # `-fn` avoids dereferencing an existing symlink that a restored cache may
+  # have pointed elsewhere.
+  if [ "$BIN_PATH" != "/opt/solc-bin/solc$version" ]; then
+    ln -sfn "$BIN_PATH" "/opt/solc-bin/solc$version"
+    echo "Linked: solc$version -> $BIN_PATH"
   fi
-  if [ ! -e "/opt/solc-bin/solc-$version" ]; then
-    ln -s "$BIN_PATH" "/opt/solc-bin/solc-$version"
-    echo "Created symlink: solc-$version -> $BIN_PATH"
+  if [ "$BIN_PATH" != "/opt/solc-bin/solc-$version" ]; then
+    ln -sfn "$BIN_PATH" "/opt/solc-bin/solc-$version"
+    echo "Linked: solc-$version -> $BIN_PATH"
   fi
 
   # Create a symlink for the first version if the binary name isn't already 'solc'
   if [ "$FIRST_VERSION" = true ] && [ "$BIN_PATH" != "/opt/solc-bin/solc" ]; then
-    rm -f /opt/solc-bin/solc # Remove existing symlink if it exists
-    ln -s "$BIN_PATH" /opt/solc-bin/solc
-    echo "Created symlink: solc -> solc$use_version"
-    solc --version
+    ln -sfn "$BIN_PATH" /opt/solc-bin/solc
+    echo "Linked: solc -> solc$use_version"
+    /opt/solc-bin/solc --version
     FIRST_VERSION=false
   fi
 done

--- a/scripts/solc-download.sh
+++ b/scripts/solc-download.sh
@@ -7,6 +7,8 @@ if [ "$DEBUG_LEVEL" -gt 0 ]; then
 fi
 
 REMOVE_PREFIX="$1"
+VERSIONS="${*:2}"
+[ -z "$VERSIONS" ] && exit 0
 
 mkdir -p /opt/solc-bin
 
@@ -14,7 +16,30 @@ GH_LINK='https://api.github.com/repos/argotorg/solidity/releases/tags/v'
 JQ_FILTER='.assets[] | select(.name == "solc-static-linux") | .url'
 AUTH_HEADER="Authorization: Bearer ${GITHUB_TOKEN}"
 
-VERSIONS="${*:2}"
+# Solidity's published binary index. We verify the SHA-256 of every downloaded
+# (and previously cached) compiler against this list before use. Mirrors
+# github.com/ethereum/solc-bin; same approach as Foundry's svm-rs.
+LIST_URL='https://binaries.soliditylang.org/linux-amd64/list.json'
+LIST_JSON=$(curl -sSfL --retry 3 --max-time 30 "$LIST_URL")
+if [ -z "$LIST_JSON" ]; then
+  echo "Failed to fetch $LIST_URL"
+  exit 1
+fi
+
+verify_sha256() {
+  local v="$1" path="$2" expected actual
+  expected=$(jq -r --arg v "$v" '.releases[$v] as $p | .builds[] | select(.path == $p) | .sha256' <<<"$LIST_JSON")
+  if [ -z "$expected" ] || [ "$expected" = "null" ]; then
+    echo "No SHA-256 reference for solc $v in $LIST_URL"
+    return 1
+  fi
+  actual="0x$(sha256sum "$path" | awk '{print $1}')"
+  if [ "$actual" != "$expected" ]; then
+    echo "SHA-256 mismatch for solc $v: expected $expected, got $actual"
+    return 1
+  fi
+}
+
 FIRST_VERSION=true # Flag to track the first version
 
 for version in $VERSIONS; do
@@ -38,14 +63,22 @@ for version in $VERSIONS; do
     fi
     BIN_LINK=$(jq -r "$JQ_FILTER" <<<"$RELEASE_DETAIL")
 
+    # Download to a temp path, verify SHA-256, then move into place. Prevents
+    # a partial/unverified binary from being trusted on a subsequent run.
+    TMP_PATH="${BIN_PATH}.tmp.$$"
     curl -sSfL --retry 3 --max-time 90 \
       -H "Accept: application/octet-stream" \
       -H "$AUTH_HEADER" \
-      "${BIN_LINK}" -o "$BIN_PATH"
+      "${BIN_LINK}" -o "$TMP_PATH"
 
-    # Verify the binary
+    verify_sha256 "$version" "$TMP_PATH" || { rm -f "$TMP_PATH"; exit 1; }
+
+    mv "$TMP_PATH" "$BIN_PATH"
     chmod +x "$BIN_PATH"
-    "solc$use_version" --version
+    "$BIN_PATH" --version
+  else
+    # Re-verify cached binaries to avoid trusting a tampered cache path.
+    verify_sha256 "$version" "$BIN_PATH"
   fi
 
   # create two symlinks for the binary, solc$version and solc-$version if they don't exist


### PR DESCRIPTION
## Summary
- Verify every downloaded (and cached) solc binary against Solidity's published SHA-256 index at `binaries.soliditylang.org/linux-amd64/list.json` before it is used.
- Same checksum source used by Foundry's `svm-rs`. The list is a mirror of `ethereum/solc-bin`.
- Hard-fail on mismatch is intentional — this is an integrity check, not best-effort.

## Why
Today `scripts/solc-download.sh` only runs `solc --version` after download, which is an executability check, not an integrity check. A SecOps review of the action surfaced this as a supply-chain gap. This patch closes it with the established ecosystem mechanism.

## What changed in `scripts/solc-download.sh`
- Pre-fetch `list.json` once at startup.
- `verify_sha256()` resolves the canonical release path via `.releases[<version>]` (avoids prerelease ambiguity — `0.8.35` and `0.8.35-pre.1` both appear under `.builds[].version`, and some stable entries carry `"prerelease": null` which would break a naive negative filter).
- Download to a temp path, verify, then `mv` into place. Prevents a partial/unverified binary from contaminating the cache path.
- Re-verify on cache hit — otherwise a tampered `/opt/solc-bin/solcX` would be used without check.
- Recreate per-version symlinks (`solc$version`, `solc-$version`, `solc`) unconditionally with `ln -sfn`. Previously they were skipped if the path already existed, so a restored cache could keep a symlink pointing somewhere other than the just-verified `$BIN_PATH`.
- Early-exit when no versions were requested, so the action doesn't make a network call it didn't before.
- Use `"$BIN_PATH" --version` (and `/opt/solc-bin/solc --version`) for sanity checks — no longer PATH-dependent.

## Empirical verification
Validated `.releases[<v>]` resolution and SHA matching across the historical range: `0.4.26, 0.5.17, 0.6.12, 0.7.6, 0.8.0, 0.8.18, 0.8.20, 0.8.35` — every version resolves to exactly one canonical path and SHA, and the bytes published in argotorg releases match the hashes in `list.json`.

Manually exercised `verify_sha256()` with: a valid binary (passes), a corrupted binary (mismatch detected with both SHAs printed), a version absent from `list.json` (clear error), and `set -e` propagation (exit code propagates correctly).

## Backward compatibility
For honest clients pinning stable solc versions: zero behavior change. The only paths to a CI failure are:
1. A tampered binary — exactly the bug being fixed.
2. A brand-new solc release not yet in `list.json` — `solc-bin` lags by hours at most; workaround is to pin to a slightly earlier patch until the index updates.

## Limitations / out of scope
- This is a checksum integrity check, not full authenticity. If `binaries.soliditylang.org` or the runner's CA trust were compromised this would not save us; GPG signature verification would close that gap and could be a follow-up.
- Linux-only, matching the rest of the script (`solc-static-linux` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)