### PR TITLE
Add flags to enable shared workspace for compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ General inputs for:
 - `certora-key` - API key for Certora Prover.
 - `working-directory` - Working directory to run the action in (optional). Default is the root of the repository.
 - `use-hard-links` - Whether to use hard links when copying files (optional). If you expect to modify the files in the run directory during `certoraRun` execution, you should set this to `false`.
+- `use-workspace-dir` - Run all configurations directly in the working directory instead of copying it to an isolated temporary directory per configuration (optional). Default is `false`.
+- `run-serially` - Run configurations one at a time instead of concurrently (optional). Default is `false`.
+- `cleanup-internal-dirs` - Delete each run's `.certora_internal` build directory after its job has been submitted, so they do not accumulate and fill the disk (optional). Default is `false`.
 - `debug-level` - Debug level for the action (optional). Default is `0`. Possible values are `0`, `1`, `2`, and `3`. Higher values will produce more debug output.
 - `gh-review` - When to add a review comment to the PR. Options are `always`, `failure`, and `never`. Default is `always`.
 - `gh-review-jobs` - Which jobs to include in the GitHub review comment. Options are `all`, `failed`. Default is `all`.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ General inputs for:
 - `use-hard-links` - Whether to use hard links when copying files (optional). If you expect to modify the files in the run directory during `certoraRun` execution, you should set this to `false`.
 - `use-workspace-dir` - Run all configurations directly in the working directory instead of copying it to an isolated temporary directory per configuration (optional). This can help with jobs failing due to out-of-memory errors (usually on Solana). If different configurations produce different build outputs, also enable `run-serially` to avoid concurrent runs racing on those outputs in the shared working directory. Default is `false`.
 - `run-serially` - Run configurations one at a time instead of concurrently (optional). Default is `false`.
-- `cleanup-internal-dirs` - Delete each run's `.certora_internal` build directory after its job has been submitted, so they do not accumulate and fill the disk (optional). Consider using this when large jobs run into `No space left on device` errors. Default is `false`.
 - `debug-level` - Debug level for the action (optional). Default is `0`. Possible values are `0`, `1`, `2`, and `3`. Higher values will produce more debug output.
 - `gh-review` - When to add a review comment to the PR. Options are `always`, `failure`, and `never`. Default is `always`.
 - `gh-review-jobs` - Which jobs to include in the GitHub review comment. Options are `all`, `failed`. Default is `all`.

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ General inputs for:
 - `certora-key` - API key for Certora Prover.
 - `working-directory` - Working directory to run the action in (optional). Default is the root of the repository.
 - `use-hard-links` - Whether to use hard links when copying files (optional). If you expect to modify the files in the run directory during `certoraRun` execution, you should set this to `false`.
-- `use-workspace-dir` - Run all configurations directly in the working directory instead of copying it to an isolated temporary directory per configuration (optional). Default is `false`.
+- `use-workspace-dir` - Run all configurations directly in the working directory instead of copying it to an isolated temporary directory per configuration (optional). This can help with jobs failing due to out-of-memory errors (usually on Solana). If different configurations produce different build outputs, also enable `run-serially` to avoid concurrent runs racing on those outputs in the shared working directory. Default is `false`.
 - `run-serially` - Run configurations one at a time instead of concurrently (optional). Default is `false`.
-- `cleanup-internal-dirs` - Delete each run's `.certora_internal` build directory after its job has been submitted, so they do not accumulate and fill the disk (optional). Default is `false`.
+- `cleanup-internal-dirs` - Delete each run's `.certora_internal` build directory after its job has been submitted, so they do not accumulate and fill the disk (optional). Consider using this when large jobs run into `No space left on device` errors. Default is `false`.
 - `debug-level` - Debug level for the action (optional). Default is `0`. Possible values are `0`, `1`, `2`, and `3`. Higher values will produce more debug output.
 - `gh-review` - When to add a review comment to the PR. Options are `always`, `failure`, and `never`. Default is `always`.
 - `gh-review-jobs` - Which jobs to include in the GitHub review comment. Options are `all`, `failed`. Default is `all`.

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ inputs:
       for more details on available options.
   use-hard-links:
     required: false
-    default: "false"
+    default: "true"
     description: |-
       Whether to use hard links when copying files. Default is `true`.
   use-workspace-dir:

--- a/action.yml
+++ b/action.yml
@@ -155,12 +155,6 @@ inputs:
     default: "false"
     description: |-
       Whether to run configurations one at a time instead of concurrently. Default is `false`.
-  cleanup-internal-dirs:
-    required: false
-    default: "false"
-    description: |-
-      Whether to delete each run's `.certora_internal` build directory after its job has
-      been submitted, so they do not accumulate and fill the disk. Default is `false`.
   vyper-version:
     required: false
     description: |-

--- a/action.yml
+++ b/action.yml
@@ -141,9 +141,26 @@ inputs:
       for more details on available options.
   use-hard-links:
     required: false
-    default: "true"
+    default: "false"
     description: |-
       Whether to use hard links when copying files. Default is `true`.
+  use-workspace-dir:
+    required: false
+    default: "false"
+    description: |-
+      Whether to run all configurations directly in the working directory instead of
+      copying it to an isolated temporary directory per configuration. Default is `false`.
+  run-serially:
+    required: false
+    default: "false"
+    description: |-
+      Whether to run configurations one at a time instead of concurrently. Default is `false`.
+  cleanup-internal-dirs:
+    required: false
+    default: "false"
+    description: |-
+      Whether to delete each run's `.certora_internal` build directory after its job has
+      been submitted, so they do not accumulate and fill the disk. Default is `false`.
   vyper-version:
     required: false
     description: |-
@@ -385,6 +402,9 @@ runs:
         CERTORA_ECOSYSTEM: "${{ inputs.ecosystem }}"
         DEBUG_LEVEL: "${{ inputs.debug-level }}"
         CERTORA_USE_HARD_LINKS: "${{ inputs.use-hard-links }}"
+        CERTORA_USE_WORKSPACE_DIR: "${{ inputs.use-workspace-dir }}"
+        CERTORA_RUN_SERIALLY: "${{ inputs.run-serially }}"
+        CERTORA_CLEANUP_INTERNAL_DIRS: "${{ inputs.cleanup-internal-dirs }}"
         CERTORA_REPLACE_COMMENTS: "${{ inputs.replace-comments }}"
         CERTORA_GH_REVIEW: "${{ inputs.gh-review }}"
         CERTORA_GH_REVIEW_JOBS: "${{ inputs.gh-review-jobs }}"

--- a/action.yml
+++ b/action.yml
@@ -398,7 +398,6 @@ runs:
         CERTORA_USE_HARD_LINKS: "${{ inputs.use-hard-links }}"
         CERTORA_USE_WORKSPACE_DIR: "${{ inputs.use-workspace-dir }}"
         CERTORA_RUN_SERIALLY: "${{ inputs.run-serially }}"
-        CERTORA_CLEANUP_INTERNAL_DIRS: "${{ inputs.cleanup-internal-dirs }}"
         CERTORA_REPLACE_COMMENTS: "${{ inputs.replace-comments }}"
         CERTORA_GH_REVIEW: "${{ inputs.gh-review }}"
         CERTORA_GH_REVIEW_JOBS: "${{ inputs.gh-review-jobs }}"

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -52,6 +52,12 @@ uvx --from "$CERT_CLI_PACKAGE" "$CLI_ENTRYPOINT" --version
 
 current_dir="$(pwd)"
 
+# Sharing one working directory across concurrent runs lets them race on shared
+# build artifacts (e.g. a common cargo target/ directory).
+if [[ "$CERTORA_USE_WORKSPACE_DIR" == "true" && "$CERTORA_RUN_SERIALLY" != "true" ]]; then
+  echo "::warning title=Possible race conditions::use-workspace-dir is true but run-serially is false: configurations run concurrently in a shared working directory and may race on shared build artifacts. Consider setting run-serially to true."
+fi
+
 # Create all folders and copy/link all files before any certoraRun executions
 # in case we need to modify them
 if [[ "$CERTORA_USE_WORKSPACE_DIR" != "true" ]]; then

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -11,6 +11,10 @@ USE_WORKSPACE_DIR=true
 # When true, run configurations one at a time instead of concurrently.
 RUN_SERIALLY=true
 
+# When true, delete a run's .certora_internal build directory once its job has
+# been submitted, so these directories don't accumulate and fill the disk.
+CLEANUP_INTERNAL_DIRS=true
+
 MAX_MSG_LEN=254
 SUFFIX_LEN=${#MESSAGE_SUFFIX}
 REMAINING_LEN=$((MAX_MSG_LEN - SUFFIX_LEN))
@@ -146,6 +150,10 @@ for conf_line in "${confs[@]}"; do
     ret=0
     wait "$pid" || ret=$?
     rets+=("$ret")
+    # Safe to delete now: nothing else is running and the job is already uploaded.
+    if [[ "$CLEANUP_INTERNAL_DIRS" == "true" ]]; then
+      rm -rf "$run_dir/.certora_internal"
+    fi
   else
     pids+=("$pid")
   fi
@@ -198,6 +206,13 @@ for i in "${!configs[@]}"; do
 
   fi
 done
+
+# In concurrent mode we cannot delete mid-run, so sweep the workspace build
+# directory now that every job has been submitted.
+# Frees disk for later certora-run steps that share the same disk.
+if [[ "$CLEANUP_INTERNAL_DIRS" == "true" && "$RUN_SERIALLY" != "true" ]]; then
+  rm -rf "$current_dir/.certora_internal"
+fi
 
 # Add jobs to output
 echo "total_jobs=$jobs" >>"$GITHUB_OUTPUT"

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -4,17 +4,6 @@ if [ "$DEBUG_LEVEL" -gt 0 ]; then
   set -x
 fi
 
-# When true, run all configurations directly in the current workspace
-# instead of creating and copying the workspace to an isolated temp dir per conf.
-USE_WORKSPACE_DIR=true
-
-# When true, run configurations one at a time instead of concurrently.
-RUN_SERIALLY=true
-
-# When true, delete a run's .certora_internal build directory once its job has
-# been submitted, so these directories don't accumulate and fill the disk.
-CLEANUP_INTERNAL_DIRS=true
-
 MAX_MSG_LEN=254
 SUFFIX_LEN=${#MESSAGE_SUFFIX}
 REMAINING_LEN=$((MAX_MSG_LEN - SUFFIX_LEN))
@@ -65,7 +54,7 @@ current_dir="$(pwd)"
 
 # Create all folders and copy/link all files before any certoraRun executions
 # in case we need to modify them
-if [[ "$USE_WORKSPACE_DIR" != "true" ]]; then
+if [[ "$CERTORA_USE_WORKSPACE_DIR" != "true" ]]; then
   for conf_line in "${confs[@]}"; do
     # Create a temporal directory for isolated executions
     # Use an MD5 hash of the configuration file as the directory name
@@ -104,7 +93,7 @@ for conf_line in "${confs[@]}"; do
 
   echo "$ACTION '$conf_line' with message: $MSG_CONF"
 
-  if [[ "$USE_WORKSPACE_DIR" == "true" ]]; then
+  if [[ "$CERTORA_USE_WORKSPACE_DIR" == "true" ]]; then
     run_dir="$current_dir"
   else
     conf_hash=$(echo -n "$conf_line" | md5sum | awk '{print $1}')
@@ -145,13 +134,13 @@ for conf_line in "${confs[@]}"; do
     >"$LOG_FILE" 2>&1 &
   pid=$!
 
-  if [[ "$RUN_SERIALLY" == "true" ]]; then
+  if [[ "$CERTORA_RUN_SERIALLY" == "true" ]]; then
     # Wait for this job before launching the next.
     ret=0
     wait "$pid" || ret=$?
     rets+=("$ret")
     # Safe to delete now: nothing else is running and the job is already uploaded.
-    if [[ "$CLEANUP_INTERNAL_DIRS" == "true" ]]; then
+    if [[ "$CERTORA_CLEANUP_INTERNAL_DIRS" == "true" ]]; then
       rm -rf "$run_dir/.certora_internal"
     fi
   else
@@ -176,7 +165,7 @@ EOF
 # Wait for all jobs to finish and mark if any failed
 failed_jobs=0
 for i in "${!configs[@]}"; do
-  if [[ "$RUN_SERIALLY" == "true" ]]; then
+  if [[ "$CERTORA_RUN_SERIALLY" == "true" ]]; then
     ret="${rets[i]}"
   else
     ret=0
@@ -210,7 +199,7 @@ done
 # In concurrent mode we cannot delete mid-run, so sweep the workspace build
 # directory now that every job has been submitted.
 # Frees disk for later certora-run steps that share the same disk.
-if [[ "$CLEANUP_INTERNAL_DIRS" == "true" && "$RUN_SERIALLY" != "true" ]]; then
+if [[ "$CERTORA_CLEANUP_INTERNAL_DIRS" == "true" && "$CERTORA_RUN_SERIALLY" != "true" ]]; then
   rm -rf "$current_dir/.certora_internal"
 fi
 

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -4,6 +4,10 @@ if [ "$DEBUG_LEVEL" -gt 0 ]; then
   set -x
 fi
 
+# When true, run all configurations directly in the current workspace
+# instead of creating and copying the workspace to an isolated temp dir per conf.
+USE_WORKSPACE_DIR=false
+
 MAX_MSG_LEN=254
 SUFFIX_LEN=${#MESSAGE_SUFFIX}
 REMAINING_LEN=$((MAX_MSG_LEN - SUFFIX_LEN))
@@ -53,21 +57,23 @@ current_dir="$(pwd)"
 
 # Create all folders and copy/link all files before any certoraRun executions
 # in case we need to modify them
-for conf_line in "${confs[@]}"; do
-  # Create a temporal directory for isolated executions
-  # Use an MD5 hash of the configuration file as the directory name
-  conf_hash=$(echo -n "$conf_line" | md5sum | awk '{print $1}')
-  run_dir="/tmp/${conf_hash}"
-  mkdir -p "$run_dir"
+if [[ "$USE_WORKSPACE_DIR" != "true" ]]; then
+  for conf_line in "${confs[@]}"; do
+    # Create a temporal directory for isolated executions
+    # Use an MD5 hash of the configuration file as the directory name
+    conf_hash=$(echo -n "$conf_line" | md5sum | awk '{print $1}')
+    run_dir="/tmp/${conf_hash}"
+    mkdir -p "$run_dir"
 
-  if [[ "$CERTORA_USE_HARD_LINKS" == "true" ]]; then
-    echo "Creating folder and hardlinks for: $conf_line ($run_dir)"
-    cp -lRP --update=none "$GITHUB_WORKSPACE/." "$run_dir/"
-  else
-    echo "Creating folder and copying files for: $conf_line ($run_dir)"
-    cp -R --update=none "$GITHUB_WORKSPACE/." "$run_dir/"
-  fi
-done
+    if [[ "$CERTORA_USE_HARD_LINKS" == "true" ]]; then
+      echo "Creating folder and hardlinks for: $conf_line ($run_dir)"
+      cp -lRP --update=none "$GITHUB_WORKSPACE/." "$run_dir/"
+    else
+      echo "Creating folder and copying files for: $conf_line ($run_dir)"
+      cp -R --update=none "$GITHUB_WORKSPACE/." "$run_dir/"
+    fi
+  done
+fi
 
 for conf_line in "${confs[@]}"; do
 
@@ -89,13 +95,18 @@ for conf_line in "${confs[@]}"; do
   fi
 
   echo "$ACTION '$conf_line' with message: $MSG_CONF"
-  conf_hash=$(echo -n "$conf_line" | md5sum | awk '{print $1}')
-  run_dir="/tmp/${conf_hash}"
 
-  # If we're using github.working-directory we have changed the run directory relative
-  # to the workspace
-  if [[ "$current_dir" != "$GITHUB_WORKSPACE" ]]; then
-    run_dir="$run_dir/$(realpath --relative-to="$GITHUB_WORKSPACE" "$current_dir")"
+  if [[ "$USE_WORKSPACE_DIR" == "true" ]]; then
+    run_dir="$current_dir"
+  else
+    conf_hash=$(echo -n "$conf_line" | md5sum | awk '{print $1}')
+    run_dir="/tmp/${conf_hash}"
+
+    # If we're using github.working-directory we have changed the run directory relative
+    # to the workspace
+    if [[ "$current_dir" != "$GITHUB_WORKSPACE" ]]; then
+      run_dir="$run_dir/$(realpath --relative-to="$GITHUB_WORKSPACE" "$current_dir")"
+    fi
   fi
 
   # Create log files

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -8,12 +8,16 @@ fi
 # instead of creating and copying the workspace to an isolated temp dir per conf.
 USE_WORKSPACE_DIR=true
 
+# When true, run configurations one at a time instead of concurrently.
+RUN_SERIALLY=true
+
 MAX_MSG_LEN=254
 SUFFIX_LEN=${#MESSAGE_SUFFIX}
 REMAINING_LEN=$((MAX_MSG_LEN - SUFFIX_LEN))
 jobs=0
 
 pids=()
+rets=()
 configs=()
 logs=()
 
@@ -135,8 +139,16 @@ for conf_line in "${confs[@]}"; do
     --group_id "$GROUP_ID" \
     --wait_for_results none \
     >"$LOG_FILE" 2>&1 &
+  pid=$!
 
-  pids+=($!)
+  if [[ "$RUN_SERIALLY" == "true" ]]; then
+    # Wait for this job before launching the next.
+    ret=0
+    wait "$pid" || ret=$?
+    rets+=("$ret")
+  else
+    pids+=("$pid")
+  fi
   configs+=("$conf_line")
 
   ((jobs++)) || true
@@ -155,9 +167,13 @@ EOF
 
 # Wait for all jobs to finish and mark if any failed
 failed_jobs=0
-for i in "${!pids[@]}"; do
-  ret=0
-  wait "${pids[i]}" || ret=$?
+for i in "${!configs[@]}"; do
+  if [[ "$RUN_SERIALLY" == "true" ]]; then
+    ret="${rets[i]}"
+  else
+    ret=0
+    wait "${pids[i]}" || ret=$?
+  fi
   conf="${configs[i]}"
   if [[ $ret -ne 0 ]]; then
     ((jobs--)) || true

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -6,7 +6,7 @@ fi
 
 # When true, run all configurations directly in the current workspace
 # instead of creating and copying the workspace to an isolated temp dir per conf.
-USE_WORKSPACE_DIR=false
+USE_WORKSPACE_DIR=true
 
 MAX_MSG_LEN=254
 SUFFIX_LEN=${#MESSAGE_SUFFIX}

--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -145,10 +145,6 @@ for conf_line in "${confs[@]}"; do
     ret=0
     wait "$pid" || ret=$?
     rets+=("$ret")
-    # Safe to delete now: nothing else is running and the job is already uploaded.
-    if [[ "$CERTORA_CLEANUP_INTERNAL_DIRS" == "true" ]]; then
-      rm -rf "$run_dir/.certora_internal"
-    fi
   else
     pids+=("$pid")
   fi
@@ -201,13 +197,6 @@ for i in "${!configs[@]}"; do
 
   fi
 done
-
-# In concurrent mode we cannot delete mid-run, so sweep the workspace build
-# directory now that every job has been submitted.
-# Frees disk for later certora-run steps that share the same disk.
-if [[ "$CERTORA_CLEANUP_INTERNAL_DIRS" == "true" && "$CERTORA_RUN_SERIALLY" != "true" ]]; then
-  rm -rf "$current_dir/.certora_internal"
-fi
 
 # Add jobs to output
 echo "total_jobs=$jobs" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
## 🚀 Pull Request Overview

- **Related Issues/Tickets**: https://certora.atlassian.net/browse/CERT-9988
- **Type of Change** (bugfix, feature, refactor, etc.): Feature, performance improvement.
- **Breaking Changes?**: No. All changes are guarded behind flags that are neither required nor active by default.

## Summary

Adds three optional inputs that control how configurations are isolated, scheduled, and cleaned up during a run. All default to false, so behavior is unchanged unless a workflow opts in:

Input | Env var | Default | Effect when true
-- | -- | -- | --
use-workspace-dir | CERTORA_USE_WORKSPACE_DIR | false | Run every configuration directly in the working directory instead of copying it to a /tmp/<hash> directory per configuration.
run-serially | CERTORA_RUN_SERIALLY | false | Submit configurations one at a time instead of concurrently.


This helps bringing memory usage, runtime, and disk usage for Solana project down.

## The Problem this Fixes

The Solana prover invokes cargo to build the project, and cargo maintains build cache local to the project directory. When the project is copied to a separate temporary folder per config file, that cache cannot be reused: each copy builds from scratch. On jobs with many confs and large builds, these concurrent isolated builds can lead to long runtimes or OOM errors on the runner.

Enabling the new `use-workspace-dir` runs all confs in the same workspace instead, so they share one build cache, reducing total runtime and memory usage. 

Note that Cargo locks the build directory, so only one compilation runs at a time per workspace; compilation is never concurrent on the same workspace.
However, all confs still write to the same output path. When different conf files enable different cargo features, a later build can overwrite an earlier conf's artifacts before they are submitted, so the wrong binary gets verified. The `run-serially` flag prevents this by letting each conf finish building and submitting before the next starts. A warning is issued in the logs when `use-workspace-dir` is enabled but `run-serially` is not.

~~Finally, the `cleanup-internal-dirs` is needed for larger codebases whose build artifacts in the `.certora_internal` directory fill up the storage space of the runner, leading to `out of device memory` errors.~~

### Comparison to existing v2 runner on Klend

The original problem explained above surfaced on KLend, as explained in this [ticket](https://certora.atlassian.net/browse/CERT-9988). The existing v2 runner could handle at most 7 confs per job without OOM errors; and even with just 7 confs, the job took roughly one hour to complete (unfortunately, the original runs linked in the ticket have been pruned).  When enabling the above flags, the same 7 conf job finishes in 18 minutes ([check run here](https://github.com/Certora/klend-audit/actions/runs/28022435897/job/82941824680?pr=52)).

## Changes Summary

- `action.yml`: 3 new inputs, wired into the Certora Run step's env (mirrors inputs).
- `scripts/run-certora.sh`: gate the copy loop behind use-workspace-dir; run jobs serially (capturing exit codes inline) vs concurrently behind run-serially; ~~per-job cleanup in serial mode plus an end-of-run sweep in concurrent mode;~~ emit a race-condition warning.
- `README.md`: document the three inputs.

---

### 📜 Tests Checklist

Before submitting this PR, ensure that all tests pass **and** meet the following conditions:

| Category                  | Status                          | Compilation Comment | Results Review |
|---------------------------|----------------------------------|----------------------|----------------|
| **fail_to_start**         | ❌ Failed with compilation error | 🟢 Yes               | 🔴 No          |
| **violated_rules**        | ✅ Passed, with violations found | 🔴 No                | 🟢 Yes         |
| **verified_rules**        | ✅ Passed without violations     | 🔴 No                | 🟢 Yes         |
| **solana_violated_rules** | ✅ Passed, with violations found | 🔴 No                | 🟢 Yes         |
| **sui_verified_rules**    | ✅ Passed without violations     | 🔴 No                | 🟢 Yes         |

> Please verify that your changes meet the above conditions for each category of tests.  
> If something doesn't match, investigate before submitting the PR.

---

### 📋 Additional Notes (Optional)

- Any risks, edge cases, or implementation notes for reviewers:
