### PR TITLE
Replace eval arg parsing

### DIFF
--- a/scripts/run-certora.sh
+++ b/scripts/run-certora.sh
@@ -79,7 +79,16 @@ for conf_line in "${confs[@]}"; do
   fi
 
   conf_parts=()
-  eval "conf_parts=($conf_line)"
+  conf_tmp="$(mktemp)"  # TMP file so we can check exit status of xargs
+  # Split into words honoring quotes
+  if ! printf '%s' "$conf_line" | xargs -r printf '%s\0' > "$conf_tmp"; then
+    # xargs exits non-zero on unbalanced quotes
+    echo "::error title=Invalid Configuration::Could not parse configuration line (check for unbalanced quotes): $conf_line"
+    rm -f "$conf_tmp"
+    exit 1
+  fi
+  mapfile -t -d '' conf_parts < "$conf_tmp"  # read NUL-delimited words into the array
+  rm -f "$conf_tmp"
   conf_file="${conf_parts[0]}"
 
   if [[ "$CERTORA_COMPILATION_STEPS_ONLY" == 'true' ]]; then


### PR DESCRIPTION
## 🚀 Pull Request Overview

Replace `eval` with `printf` and `xargs`. 

- **Related Issues/Tickets**: 
- **Type of Change** (bugfix, feature, refactor, etc.): 
- **Breaking Changes?**: 

---

### 📜 Tests Checklist

Before submitting this PR, ensure that all tests pass **and** meet the following conditions:

| Category                  | Status                          | Compilation Comment | Results Review |
|---------------------------|----------------------------------|----------------------|----------------|
| **fail_to_start**         | ❌ Failed with compilation error | 🟢 Yes               | 🔴 No          |
| **violated_rules**        | ✅ Passed, with violations found | 🔴 No                | 🟢 Yes         |
| **verified_rules**        | ✅ Passed without violations     | 🔴 No                | 🟢 Yes         |
| **solana_violated_rules** | ✅ Passed, with violations found | 🔴 No                | 🟢 Yes         |
| **sui_verified_rules**    | ✅ Passed without violations     | 🔴 No                | 🟢 Yes         |

> Please verify that your changes meet the above conditions for each category of tests.  
> If something doesn't match, investigate before submitting the PR.

---

### 📋 Additional Notes (Optional)

- Using `xargs` removes the ability to use shell expansion and there might be some edge cases for things like escaped quotes etc. that are quite rare in normal config definitions.
