### PR TITLE
Bump rust-setup-action to hash-pinned revision

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -374,7 +374,7 @@ runs:
 
     - name: Install rust for solana
       if: ${{ inputs.ecosystem == 'solana' && inputs.rust-setup == 'true' }}
-      uses: Certora/rust-setup-action@e161cd3ac1058b733d94726531a42775d85e4b9c # v1.0.1
+      uses: Certora/rust-setup-action@31bcffb38fc673ba728377e6613cee933d603361 # main @ 2026-07-07 (#1)
       with:
         version: ${{ inputs.rust-version }}
         additional-versions: ${{ inputs.rust-additional-versions }}


### PR DESCRIPTION
## What

Update the `Certora/rust-setup-action` pin in `action.yml` ("Install rust for solana" step):

```diff
- uses: Certora/rust-setup-action@e161cd3ac1058b733d94726531a42775d85e4b9c # v1.0.1
+ uses: Certora/rust-setup-action@31bcffb38fc673ba728377e6613cee933d603361 # main @ 2026-07-07 (#1)
```

## Why

`v1.0.1` of `rust-setup-action` internally referenced `actions/cache@v4` — a **floating tag**. So even though this repo pins `rust-setup-action` by SHA, that transitive dependency still resolved to a mutable ref at runtime, leaving a gap in the hash-pinning done in the earlier "Pin all actions" PR.

[Certora/rust-setup-action#1](https://github.com/Certora/rust-setup-action/pull/1) (now merged to `main`, HEAD `31bcffb`) pins that `actions/cache` reference to a commit SHA (upgraded v4 → v6.1.0, matching this repo) and adds Dependabot. This PR advances our pin to that revision so the whole tree is fully hash-locked.

`rust-setup-action` has no release tag past `v1.0.1` yet, so we pin to the `main` merge commit directly; Dependabot / a future `v1.0.2` can advance it.